### PR TITLE
Fix typos

### DIFF
--- a/kubernetes/manifest/variables.tf
+++ b/kubernetes/manifest/variables.tf
@@ -21,7 +21,7 @@ variable "metadata" {
 }
 
 # Map elements must have the same type in Terraform.
-# We need to support here higly dynamic data.
+# We need to support here highly dynamic data.
 variable "spec" {
   type    = any
   default = null

--- a/kubernetes/manifest/versions.tf
+++ b/kubernetes/manifest/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     kubernetes = {
-      source  = "kubernets"
+      source  = "hashicorp/kubernetes"
       version = ">= 2.20.0"
     }
   }


### PR DESCRIPTION
There is a typo in a provider name. While both `kubernetes` and `hashicorp/kubernetes` are working option, I think it's better to specify that Hashicord provider is required.

There is said in [main.tf](https://github.com/pulecp/tf-modules/blob/main/kubernetes/manifest/main.tf#L2) that `var.spec` can't be null. I don't see a reason why it should be set to null by default. It's better when this parameter is required and so I removed the default value for this variable.